### PR TITLE
Support expand element - Fixes #41

### DIFF
--- a/server/CHANGELOG.md
+++ b/server/CHANGELOG.md
@@ -1,6 +1,17 @@
 # Galaxy Language Server Changelog
 
-## [0.1.0]
+## [Unreleased]
+
+### Added
+
+- Support autocompletion for ``<expand>`` element.
+
+### Fixed
+
+- Fix error when hovering ``<expand>`` elements or it's atributes.
+
+
+## [0.1.0] - 2020-10-14
 
 ### Added
 

--- a/server/galaxyls/services/completion.py
+++ b/server/galaxyls/services/completion.py
@@ -54,6 +54,7 @@ class XmlCompletionService:
         elif context.node:
             for child in context.node.children:
                 result.append(self._build_node_completion_item(child, len(result)))
+            result.append(self._build_node_completion_item(self.xsd_tree.expand_element, len(result)))
         return CompletionList(items=result, is_incomplete=False)
 
     def get_attribute_completion(self, context: XmlContext) -> CompletionList:

--- a/server/galaxyls/services/xsd/service.py
+++ b/server/galaxyls/services/xsd/service.py
@@ -13,6 +13,8 @@ from .parser import GalaxyToolXsdParser
 from .validation import GalaxyToolValidationService
 from ..context import XmlContext
 
+NO_DOC_MARKUP = MarkupContent(MarkupKind.Markdown, MSG_NO_DOCUMENTATION_AVAILABLE)
+
 
 class GalaxyToolXsdService:
     """Galaxy tool Xml Schema Definition service.
@@ -41,11 +43,13 @@ class GalaxyToolXsdService:
         """
         tree = self.xsd_parser.get_tree()
         node = tree.find_node_by_stack(context.node_stack)
+        if node is None:
+            return NO_DOC_MARKUP
         element = None
         if context.is_tag():
             element = node
         if context.is_attribute_key():
             element = node.attributes.get(context.token_name)
         if element is None:
-            return MarkupContent(MarkupKind.Markdown, MSG_NO_DOCUMENTATION_AVAILABLE)
+            return NO_DOC_MARKUP
         return element.get_doc()

--- a/server/galaxyls/tests/unit/test_completion.py
+++ b/server/galaxyls/tests/unit/test_completion.py
@@ -85,9 +85,11 @@ class TestXmlCompletionServiceClass:
         actual = service.get_completion_at_context(fake_context, fake_completion_context)
 
         assert actual
-        assert len(actual.items) == 1
+        assert len(actual.items) == 2
         assert actual.items[0].label == "child"
         assert actual.items[0].kind == CompletionItemKind.Class
+        assert actual.items[1].label == "expand"
+        assert actual.items[1].kind == CompletionItemKind.Class
 
     def test_get_completion_at_context_on_node_returns_expected_attributes(self, fake_tree: XsdTree) -> None:
         fake_context = XmlContext()
@@ -147,8 +149,9 @@ class TestXmlCompletionServiceClass:
 
         actual = service.get_node_completion(fake_context_on_root_node)
 
-        assert len(actual.items) == 1
+        assert len(actual.items) == 2
         assert actual.items[0].label == fake_tree.root.children[0].name
+        assert actual.items[1].label == "expand"
 
     def test_completion_return_root_node_when_empty_context(self, fake_tree: XsdTree, fake_empty_context) -> None:
         service = XmlCompletionService(fake_tree)
@@ -172,9 +175,7 @@ class TestXmlCompletionServiceClass:
 
         assert len(actual.items) > 0
 
-    def test_return_valid_attribute_value_completion_when_enum_context(
-        self, fake_tree: XsdTree, fake_context_on_root_node
-    ) -> None:
+    def test_return_valid_attribute_value_completion_when_enum_context(self, fake_tree: XsdTree) -> None:
         fake_context = XmlContext()
         fake_context.is_empty = False
         fake_context.token_type = ContextTokenType.ATTRIBUTE_VALUE

--- a/server/galaxyls/tests/unit/test_xsd_parser.py
+++ b/server/galaxyls/tests/unit/test_xsd_parser.py
@@ -100,6 +100,23 @@ class TestXsdParserClass:
 
         assert node.name == expected
 
+    @pytest.mark.parametrize(
+        "stack, expected",
+        [
+            (["expand"], "expand",),
+            (["testElement", "expand"], "expand",),
+            (["testElement", "element_with_group", "expand"], "expand",),
+        ],
+    )
+    def test_tree_find_node_by_stack_ending_with_expand_returns_expand_node(
+        self, xsd_parser: GalaxyToolXsdParser, stack: List[str], expected: str
+    ) -> None:
+        tree = xsd_parser.get_tree()
+
+        node = tree.find_node_by_stack(stack)
+
+        assert node.name == expected
+
     def test_tree_find_node_by_name_returns_None_when_node_not_found(self, xsd_parser: GalaxyToolXsdParser) -> None:
         tree = xsd_parser.get_tree()
 

--- a/server/galaxyls/tests/unit/test_xsd_service.py
+++ b/server/galaxyls/tests/unit/test_xsd_service.py
@@ -1,0 +1,17 @@
+from ...services.context import ContextTokenType, XmlContext
+from ...services.xsd.service import GalaxyToolXsdService
+from ...services.xsd.constants import MSG_NO_DOCUMENTATION_AVAILABLE
+
+
+class TestXsdServiceClass:
+    def test_get_documentation_for_unknown_node_attribute_returns_no_documentation(self) -> None:
+        fake_context = XmlContext()
+        fake_context.is_empty = False
+        fake_context.token_type = ContextTokenType.ATTRIBUTE_KEY
+        fake_context.token_name = "uknownAttr"
+        fake_context.node_stack = ["uknown"]
+        service = GalaxyToolXsdService("Test")
+
+        doc = service.get_documentation_for(fake_context)
+
+        assert doc.value == MSG_NO_DOCUMENTATION_AVAILABLE


### PR DESCRIPTION
The ``<expand>`` element for macros is now better supported:
- This element is defined directly in the [XsdTree](https://github.com/davelopez/galaxy-language-server/compare/support-expand-element?expand=1#diff-2a462b2b25c733314371cb45981f8e26f25b5fe68cfb3793c14142ec56c47c3dR104) since it can not be added to the XSD schema itself.
- The ``expand`` tag will be now displayed in the auto-completion list of every element.
- The error when hovering the ``<expand>`` element has been fixed #41.