### PR TITLE
Fix bug installing language server on Unix

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -1,18 +1,23 @@
 # Galaxy Tools (VS Code Extension) Changelog
 
+## Unreleased
+
+### Fixed
+- Fix error preventing the installation of the language server on Unix systems.
+
 ## [0.1.1]
 
 ### Changed
 
-- Updated Galaxy Language Server [v0.1.1](./server/CHANGELOG.md#011)
-- Improved language server installation
-- Updated some dependencies
+- Updated Galaxy Language Server [v0.1.1](./server/CHANGELOG.md#011).
+- Improved language server installation.
+- Updated some dependencies.
 
 
 ## [0.1.0]
 
 ### Added
 
-- Support for Galaxy Language Server [v0.1.0](./server/CHANGELOG.md#010)
+- Support for Galaxy Language Server [v0.1.0](./server/CHANGELOG.md#010).
 - Auto-installation of language server in the extension's virtual environment.
-- [Snippets](./client/src/snippets.json) for basic tool scaffolding
+- [Snippets](./client/src/snippets.json) for basic tool scaffolding.

--- a/client/src/setup.ts
+++ b/client/src/setup.ts
@@ -81,7 +81,7 @@ async function isPythonPackageInstalled(python: string, packageName: string, ver
     }
 
     const pattern = /Version: (?<version>\d+.\d+.\d+)/m;
-    const getPacakgeInfoCmd = `"${python}" -m pip show ${packageName}"`;
+    const getPacakgeInfoCmd = `"${python}" -m pip show ${packageName}`;
     try {
         const packageInfo = await execAsync(getPacakgeInfoCmd);
         const match = packageInfo.match(new RegExp(pattern));


### PR DESCRIPTION
In version 0.1.1 of the extension. there was a trailing double-quotes character left in one of the commands for the language server installation.
This doesn't seem to affect the installation on Windows but was breaking the installation on Unix systems 😅 

This PR fixes #48 