### PR TITLE
Feature auto indent

### DIFF
--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -1,0 +1,12 @@
+{
+    "rules": {
+        "semi": [
+            "error",
+            "always"
+        ],
+        "quotes": [
+            "error",
+            "double"
+        ]
+    }
+}

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -9,61 +9,19 @@ import { GALAXY_LS } from './constants';
 
 let client: LanguageClient;
 
-function getClientOptions(): LanguageClientOptions {
-  return {
-    // Register the server for xml documents
-    documentSelector: [
-      { scheme: "file", language: "xml" },
-      { scheme: "untitled", language: "xml" },
-    ],
-    outputChannelName: "[galaxyls]",
-    synchronize: {
-
-    },
-  };
-}
-
-function isStartedInDebugMode(): boolean {
-  return process.env.VSCODE_DEBUG_MODE === "true";
-}
-
-function startLangServerTCP(port: number): LanguageClient {
-  const serverOptions: ServerOptions = () => {
-    return new Promise((resolve, reject) => {
-      const clientSocket = new net.Socket();
-      clientSocket.connect(port, "127.0.0.1", () => {
-        resolve({
-          reader: clientSocket,
-          writer: clientSocket,
-        });
-      });
-    });
-  };
-
-  return new LanguageClient(`galaxy language server tcp (port ${port})`, serverOptions, getClientOptions());
-}
-
-function startLangServer(
-  command: string, args: string[], cwd: string,
-): LanguageClient {
-  const serverOptions: ServerOptions = {
-    args,
-    command,
-    options: { cwd },
-  };
-
-  return new LanguageClient(command, serverOptions, getClientOptions());
-}
-
+/**
+ * This method gets called when the extension gets activated for the first time.
+ * @param context The extension context
+ */
 export async function activate(context: ExtensionContext) {
-  if (isStartedInDebugMode()) {
-    // Development - Run the server manually
-    client = startLangServerTCP(2087);
+  if (isDebugMode()) {
+    // Development - Connect to language server (already running) using TCP
+    client = connectToLanguageServerTCP(2087);
   } else {
-    // Production - Client is going to run the server (for use within `.vsix` package)
+    // Production - Install (first time only), launch and connect to language server.
     try {
       const python = await installLanguageServer(context);
-      client = startLangServer(python, ["-m", GALAXY_LS], context.extensionPath);
+      client = startLanguageServer(python, ["-m", GALAXY_LS], context.extensionPath);
     } catch (err) {
       window.showErrorMessage(err);
     }
@@ -80,6 +38,66 @@ export async function activate(context: ExtensionContext) {
   context.subscriptions.push(activateTagClosing(tagProvider));
 }
 
+/**
+ * Release resources when the extension gets deactivated.
+ */
 export function deactivate(): Thenable<void> {
   return client ? client.stop() : Promise.resolve();
+}
+
+
+function getClientOptions(): LanguageClientOptions {
+  return {
+    // Register the server for xml documents
+    documentSelector: [
+      { scheme: "file", language: "xml" },
+      { scheme: "untitled", language: "xml" },
+    ],
+    outputChannelName: "[galaxyls]",
+    synchronize: {
+
+    },
+  };
+}
+
+function isDebugMode(): boolean {
+  return process.env.VSCODE_DEBUG_MODE === "true";
+}
+
+/**
+ * Returns a LanguageClient instance that will connect to a Language Server running on localhost using the given port.
+ * @param port The port where the server is listening
+ */
+function connectToLanguageServerTCP(port: number): LanguageClient {
+  const serverOptions: ServerOptions = () => {
+    return new Promise((resolve, _reject) => {
+      const clientSocket = new net.Socket();
+      clientSocket.connect(port, "127.0.0.1", () => {
+        resolve({
+          reader: clientSocket,
+          writer: clientSocket,
+        });
+      });
+    });
+  };
+
+  return new LanguageClient(`galaxy language server tcp (port ${port})`, serverOptions, getClientOptions());
+}
+
+/**
+ * Launches the language server using the specified Python command.
+ * @param command The Python path in the virtual environment
+ * @param args The arguments to launch the language server
+ * @param cwd The extension's path
+ */
+function startLanguageServer(
+  command: string, args: string[], cwd: string,
+): LanguageClient {
+  const serverOptions: ServerOptions = {
+    args,
+    command,
+    options: { cwd },
+  };
+
+  return new LanguageClient(command, serverOptions, getClientOptions());
 }


### PR DESCRIPTION
In the current version, when we press `enter` inside an element, we have to manually indent the next element:
![before-auto-indent](https://user-images.githubusercontent.com/46503462/97228775-ae067b80-17d7-11eb-9de6-8bc39a07278b.gif)

This PR configures the indentation rules of the language to allow auto-indent:
![after-auto-indent](https://user-images.githubusercontent.com/46503462/97228973-f58d0780-17d7-11eb-9653-c790971a4ae6.gif)

Also, some minor refactorings and code documentation was added. 